### PR TITLE
Add vscode container/codespaces config with script

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,14 @@
+ARG VARIANT=18-bullseye
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node modules
+# RUN su node -c "npm install -g <your-package-list-here>"
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,6 @@
 	"forwardPorts": [ 8910, 8911, 5432, 5555 ],
 	// Use 'postCreateCommand' to run commands after the container is created.
 	"postCreateCommand": "bash scripts/setup.sh",
-	"postStartCommand": "yarn rw dev",
 	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+{
+	"name": "RedwoosJS & PostgreSQL",
+  "dockerComposeFile": "docker-compose.yml",
+	"service": "app",
+	"workspaceFolder": "/workspace",
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// This can be used to network with other containers or with the host.
+	"forwardPorts": [ 8910, 8911, 5432, 5555 ],
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "bash scripts/setup.sh",
+	"postStartCommand": "yarn rw dev",
+	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			// Add the IDs of extensions you want installed when the container is created.
+			"extensions": [
+				"dbaeumer.vscode-eslint",
+				"ofhumanbondage.react-proptypes-intellisense",
+				"mgmcdermott.vscode-language-babel",
+				"editorconfig.editorconfig",
+				"prisma.prisma",
+				"graphql.vscode-graphql"
+			]
+		}
+	},
+	"remoteUser": "node"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,64 @@
+version: '3.8'
+
+services:
+  app:
+    # Using a Dockerfile is optional, but included for completeness.
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        # Update 'VARIANT' to pick an LTS version of Node.js: 18, 16, 14.
+        # Append -bullseye or -buster to pin to an OS version.
+        # Use -bullseye variants on local arm64/Apple Silicon.
+        VARIANT: 18-bullseye
+
+    volumes:
+      # This is where VS Code should expect to find your project's source code and the value of "workspaceFolder" in .devcontainer/devcontainer.json
+      - ..:/workspace:cached
+
+      # Uncomment the next line to use Docker from inside the container. See https://aka.ms/vscode-remote/samples/docker-from-docker-compose for details.
+      # - /var/run/docker.sock:/var/run/docker.sock
+
+    # Overrides default command so things don't shut down after the process ends.
+    command: sleep infinity
+
+    # Runs app on the same network as the service container, allows "forwardPorts" in devcontainer.json function.
+    network_mode: service:db
+
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+    # (Adding the "ports" property to this file will not forward from a Codespace.)
+
+    # Uncomment the next line to use a non-root user for all processes - See https://aka.ms/vscode-remote/containers/non-root for details.
+    # user: vscode
+
+    # Uncomment the next four lines if you will use a ptrace-based debugger like C++, Go, and Rust.
+    # cap_add:
+    #   - SYS_PTRACE
+    # security_opt:
+    #   - seccomp:unconfined
+
+  # You can include other services not opened by VS Code as well
+  db:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: development_db
+      POSTGRES_PASSWORD: postgres
+
+  db-test:
+    image: postgres:latest
+    restart: unless-stopped
+    volumes:
+      - postgres-test-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_DB: test_db
+      POSTGRES_PASSWORD: postgres
+
+    # As in the "app" service, use "forwardPorts" in **devcontainer.json** to forward an app port locally.
+volumes:
+  postgres-data:
+  postgres-test-data:

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,15 @@
+# Cleanup terminal
+printf "\033[3J\033c\033[3J"
+
+# Auto init a redwoodjs project for Gitpod if missing
+if test ! -e redwood.toml; then {
+  # Create
+  yarn create redwood-app . --overwrite --yarn-install --typescript --git-init=false
+
+  # Change the default `sqlite` datasource provider to `postgres`
+  sed -i 's|provider = "sqlite"|provider = "postgres"|' "api/db/schema.prisma"
+} fi
+
+if test -e redwood.toml; then {
+  yarn install
+} fi


### PR DESCRIPTION
A working configuration for creating a RedwoodJS project from scratch, like the Gitpod config. To make the setup script more maintainable and easier to use with the .devcontainer.json file. I have broken it out into its own file, keeping it very minimal. This should be enough for barebones and needs tweaks for any new extensions or tweak to the script.

I removed the `postStartCommand` you originally had in the example you provided me since it was causing the codespace setup never to end. Looking into it a little further, only commands that want to run on start for additional "setup" should be run using that command option. Since `yarn rw dev` is a command developers would want to start and stop, they should be manually invoking it instead.